### PR TITLE
Clip the values of the nodes 

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -69,6 +69,12 @@ cdef class Criterion:
         self,
         double* dest
     ) noexcept nogil
+    cdef void clip_node_value(
+        self,
+        double* dest,
+        double lower_bound,
+        double upper_bound
+    ) noexcept nogil
     cdef double middle_value(self) noexcept nogil
     cdef double impurity_improvement(
         self,

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -248,16 +248,11 @@ cdef class Criterion:
                 (sum_left <= upper_bound * weighted_n_left) &
                 (sum_right <= upper_bound * weighted_n_right)
             )
-            bint check_monotonic_cst
-
-        if monotonic_cst == 0:  # No constraint
-            return 1
-        else:
-            check_monotonic_cst = (
+            bint check_monotonic_cst = (
                 (sum_left * weighted_n_right -
                  sum_right * weighted_n_left) * monotonic_cst <= 0
             )
-            return check_lower_bound & check_upper_bound & check_monotonic_cst
+        return check_lower_bound & check_upper_bound & check_monotonic_cst
 
     cdef void init_sum_missing(self):
         """Init sum_missing to hold sums for missing values."""

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -580,14 +580,17 @@ cdef class ClassificationCriterion(Criterion):
     cdef void clip_node_value(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
         """Clip the value in dest between lower_bound and upper_bound for monotonic constraints.
 
-        Assumes binary classification and single output, as supported by monotonic constraints.
+        Note that monotonicity constraints are only supported for:
+        - single-output trees and
+        - binary classifications.
         """
         if dest[0] < lower_bound:
             dest[0] = lower_bound
-            dest[1] = 1 - lower_bound
         elif dest[0] > upper_bound:
             dest[0] = upper_bound
-            dest[1] = 1 - upper_bound
+
+        # Class proportions for binary classification must sum to 1.
+        dest[1] = 1 - dest[0]
 
     cdef inline double middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -157,6 +157,9 @@ cdef class Criterion:
         """
         pass
 
+    cdef void clip_node_value(self, double* dest, double lower_bound, double upper_bound) noexcept nogil:
+        pass
+
     cdef double middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints
 
@@ -578,6 +581,18 @@ cdef class ClassificationCriterion(Criterion):
         for k in range(self.n_outputs):
             memcpy(dest, &self.sum_total[k, 0], self.n_classes[k] * sizeof(double))
             dest += self.max_n_classes
+
+    cdef void clip_node_value(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
+        """Clip the value in dest between lower_bound and upper_bound for monotonic constraints.
+
+        Assumes binary classification and single output, as supported by monotonic constraints.
+        """
+        if dest[0] < lower_bound:
+            dest[0] = lower_bound
+            dest[1] = 1 - lower_bound
+        elif dest[0] > upper_bound:
+            dest[0] = upper_bound
+            dest[1] = 1 - upper_bound
 
     cdef inline double middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average
@@ -1029,6 +1044,13 @@ cdef class RegressionCriterion(Criterion):
 
         for k in range(self.n_outputs):
             dest[k] = self.sum_total[k] / self.weighted_n_node_samples
+
+    cdef inline void clip_node_value(self, double* dest, double lower_bound, double upper_bound) noexcept nogil:
+        """Clip the value in dest between lower_bound and upper_bound for monotonic constraints."""
+        if dest[0] < lower_bound:
+            dest[0] = lower_bound
+        elif dest[0] > upper_bound:
+            dest[0] = upper_bound
 
     cdef inline double middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -248,7 +248,7 @@ cdef class Criterion:
             bint check_monotonic_cst
 
         if monotonic_cst == 0:  # No constraint
-            return check_lower_bound & check_upper_bound
+            return 1
         else:
             check_monotonic_cst = (
                 (sum_left * weighted_n_right -

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -112,4 +112,6 @@ cdef class Splitter:
 
     cdef void node_value(self, double* dest) noexcept nogil
 
+    cdef void node_value_with_monotonic_cst(self, double* dest, double lower_bound, double upper_bound) noexcept nogil
+
     cdef double node_impurity(self) noexcept nogil

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -112,6 +112,6 @@ cdef class Splitter:
 
     cdef void node_value(self, double* dest) noexcept nogil
 
-    cdef void node_value_with_monotonic_cst(self, double* dest, double lower_bound, double upper_bound) noexcept nogil
+    cdef void clip_node_value(self, double* dest, double lower_bound, double upper_bound) noexcept nogil
 
     cdef double node_impurity(self) noexcept nogil

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -247,6 +247,15 @@ cdef class Splitter:
 
         self.criterion.node_value(dest)
 
+    cdef void node_value_with_monotonic_cst(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
+        """Copy the value of node samples[start:end] into dest."""
+        cdef double val
+        self.criterion.node_value(dest)
+        val = dest[0]
+        val = max(val, lower_bound)
+        val = min(val, upper_bound)
+        dest[0] = val
+
     cdef double node_impurity(self) noexcept nogil:
         """Return the impurity of the current node."""
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -247,14 +247,13 @@ cdef class Splitter:
 
         self.criterion.node_value(dest)
 
-    cdef void node_value_with_monotonic_cst(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
+    cdef inline void clip_node_value(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
         """Copy the value of node samples[start:end] into dest."""
-        cdef double val
-        self.criterion.node_value(dest)
-        val = dest[0]
-        val = max(val, lower_bound)
-        val = min(val, upper_bound)
-        dest[0] = val
+
+        if dest[0] < lower_bound:
+            dest[0] = lower_bound
+        elif dest[0] > upper_bound:
+            dest[0] = upper_bound
 
     cdef double node_impurity(self) noexcept nogil:
         """Return the impurity of the current node."""

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -450,6 +450,7 @@ cdef inline int node_split_best(
                 # Reject if monotonicity constraints are not satisfied
                 if (
                     with_monotonic_cst and
+                    monotonic_cst[current_split.feature] != 0 and
                     not criterion.check_monotonicity(
                         monotonic_cst[current_split.feature],
                         lower_bound,
@@ -805,6 +806,7 @@ cdef inline int node_split_random(
         # Reject if monotonicity constraints are not satisfied
         if (
                 with_monotonic_cst and
+                monotonic_cst[current_split.feature] != 0 and
                 not criterion.check_monotonicity(
                     monotonic_cst[current_split.feature],
                     lower_bound,

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -247,13 +247,10 @@ cdef class Splitter:
 
         self.criterion.node_value(dest)
 
-    cdef inline void clip_node_value(self, double * dest, double lower_bound, double upper_bound) noexcept nogil:
-        """Copy the value of node samples[start:end] into dest."""
+    cdef inline void clip_node_value(self, double* dest, double lower_bound, double upper_bound) noexcept nogil:
+        """Clip the value in dest between lower_bound and upper_bound for monotonic constraints."""
 
-        if dest[0] < lower_bound:
-            dest[0] = lower_bound
-        elif dest[0] > upper_bound:
-            dest[0] = upper_bound
+        self.criterion.clip_node_value(dest, lower_bound, upper_bound)
 
     cdef double node_impurity(self) noexcept nogil:
         """Return the impurity of the current node."""

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -291,10 +291,9 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
 
                 # Store value for all nodes, to facilitate tree/model
                 # inspection and interpretation
+                splitter.node_value(tree.value + node_id * tree.value_stride)
                 if splitter.with_monotonic_cst:
-                    splitter.node_value_with_monotonic_cst(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
-                else:
-                    splitter.node_value(tree.value + node_id * tree.value_stride)
+                    splitter.clip_node_value(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
 
                 if not is_leaf:
                     if (
@@ -643,10 +642,9 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
             return -1
 
         # compute values also for split nodes (might become leafs later).
+        splitter.node_value(tree.value + node_id * tree.value_stride)
         if splitter.with_monotonic_cst:
-            splitter.node_value_with_monotonic_cst(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
-        else:
-            splitter.node_value(tree.value + node_id * tree.value_stride)
+            splitter.clip_node_value(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
 
         res.node_id = node_id
         res.start = start

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -291,7 +291,10 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
 
                 # Store value for all nodes, to facilitate tree/model
                 # inspection and interpretation
-                splitter.node_value(tree.value + node_id * tree.value_stride)
+                if splitter.with_monotonic_cst:
+                    splitter.node_value_with_monotonic_cst(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
+                else:
+                    splitter.node_value(tree.value + node_id * tree.value_stride)
 
                 if not is_leaf:
                     if (
@@ -640,7 +643,10 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
             return -1
 
         # compute values also for split nodes (might become leafs later).
-        splitter.node_value(tree.value + node_id * tree.value_stride)
+        if splitter.with_monotonic_cst:
+            splitter.node_value_with_monotonic_cst(tree.value + node_id * tree.value_stride, lower_bound, upper_bound)
+        else:
+            splitter.node_value(tree.value + node_id * tree.value_stride)
 
         res.node_id = node_id
         res.start = start

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -309,8 +309,8 @@ def assert_nd_reg_tree_children_monotonic_bounded(tree_, monotonic_cst):
     for i in range(tree_.node_count):
         feature = tree_.feature[i]
         node_value = tree_.value[i][0][0]  # unpack value from nx1x1 array
-        assert node_value <= upper_bound[i]
-        assert node_value >= lower_bound[i]
+        #assert node_value <= upper_bound[i]
+        #assert node_value >= lower_bound[i]
 
         if feature < 0:
             # Leaf: nothing to do

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -309,6 +309,12 @@ def assert_nd_reg_tree_children_monotonic_bounded(tree_, monotonic_cst):
     for i in range(tree_.node_count):
         feature = tree_.feature[i]
         node_value = tree_.value[i][0][0]  # unpack value from nx1x1 array
+        # While building the tree, the computed middle value is slightly
+        # different from the average of the siblings values, because
+        # sum_right / weighted_n_right
+        # is slightly different from the value of the right sibling.
+        # This can cause a discrepancy up to numerical noise when clipping,
+        # which is resolved by comparing with some loss of precision.
         assert np.float32(node_value) <= np.float32(upper_bound[i])
         assert np.float32(node_value) >= np.float32(lower_bound[i])
 

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -309,8 +309,8 @@ def assert_nd_reg_tree_children_monotonic_bounded(tree_, monotonic_cst):
     for i in range(tree_.node_count):
         feature = tree_.feature[i]
         node_value = tree_.value[i][0][0]  # unpack value from nx1x1 array
-        #assert node_value <= upper_bound[i]
-        #assert node_value >= lower_bound[i]
+        assert np.float32(node_value) <= np.float32(upper_bound[i])
+        assert np.float32(node_value) >= np.float32(lower_bound[i])
 
         if feature < 0:
             # Leaf: nothing to do


### PR DESCRIPTION
Clip the values of the nodes  for constrained trees instead of checking the bounds for all including unconstrained features.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
